### PR TITLE
Fix 'claim' function bug and refactoring

### DIFF
--- a/contracts/interfaces/ICumulativeMerkleDrop.sol
+++ b/contracts/interfaces/ICumulativeMerkleDrop.sol
@@ -9,6 +9,8 @@ interface ICumulativeMerkleDrop {
     event MerkelRootUpdated(bytes32 oldMerkleRoot, bytes32 newMerkleRoot);
     // This event is triggered whenever a call to #claim succeeds.
     event Claimed(address indexed stakingProvider, uint256 amount, address beneficiary, bytes32 merkleRoot);
+    // This event is triggered whenever a call to #setRewardsHolder succeeds.
+    event RewardsHolderUpdated(address oldRewardsHolder, address newRewardsHolder);
 
     // Returns the address of the token distributed by this contract.
     function token() external view returns (address);


### PR DESCRIPTION
- Claim function has been fixed.
- Events declared in contract have been placed in interface with the
  rest of events.
- Events are emitted after the state of the contract is modified.